### PR TITLE
Add EmaLink battery level in device information

### DIFF
--- a/MinimedKitUI/RileyLinkMinimedDeviceTableViewController.swift
+++ b/MinimedKitUI/RileyLinkMinimedDeviceTableViewController.swift
@@ -63,6 +63,16 @@ public class RileyLinkMinimedDeviceTableViewController: UITableViewController {
         }
     }
 
+    private var battery: String? {
+        didSet {
+            guard isViewLoaded else {
+                return
+            }
+
+            cellForRow(.battery)?.setDetailBatteryLevel(battery, device.name)
+        }
+    }
+
     private var lastIdle: Date? {
         didSet {
             guard isViewLoaded else {
@@ -115,6 +125,14 @@ public class RileyLinkMinimedDeviceTableViewController: UITableViewController {
                     self.uptime = statistics.uptime
                 }
             } catch { }
+        }
+    }
+
+    func updateBatteryLevel() {
+        device.getBatterylevel { (batteryLevel) in
+            DispatchQueue.main.async {
+                    self.battery = batteryLevel
+            }
         }
     }
 
@@ -185,6 +203,8 @@ public class RileyLinkMinimedDeviceTableViewController: UITableViewController {
         updateRSSI()
         
         updateUptime()
+
+        updateBatteryLevel()
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
@@ -238,6 +258,7 @@ public class RileyLinkMinimedDeviceTableViewController: UITableViewController {
         case connection
         case uptime
         case idleStatus
+        case battery
     }
 
     private enum PumpRow: Int, CaseCountable {
@@ -321,6 +342,9 @@ public class RileyLinkMinimedDeviceTableViewController: UITableViewController {
             case .idleStatus:
                 cell.textLabel?.text = LocalizedString("On Idle", comment: "The title of the cell showing the last idle")
                 cell.setDetailDate(lastIdle, formatter: dateFormatter)
+            case .battery:
+                cell.textLabel?.text = NSLocalizedString("Battery Level", comment: "The title of the cell showing battery level")
+                cell.setDetailBatteryLevel(battery, device.name)
             }
         case .pump:
             switch PumpRow(rawValue: indexPath.row)! {
@@ -536,6 +560,15 @@ private extension UITableViewCell {
         }
     }
     
+   func setDetailBatteryLevel(_ batteryLevel: String?, _ name: String?) {
+        if let batteryLevel = batteryLevel, let name = name {
+            // check for EmaLink within the device name
+            detailTextLabel?.text = name.lowercased().contains("emalink") ? batteryLevel + " %" : "N/A"
+        } else {
+            detailTextLabel?.text = "N/A"
+        }
+    }
+
     func setAwakeUntil(_ awakeUntil: Date?, formatter: DateFormatter) {
         switch awakeUntil {
         case let until? where until.timeIntervalSinceNow < 0:

--- a/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
+++ b/RileyLinkBLEKit/PeripheralManager+RileyLink.swift
@@ -19,6 +19,7 @@ extension CBUUIDRawValue where RawValue == String {
 
 enum RileyLinkServiceUUID: String, CBUUIDRawValue {
     case main = "0235733B-99C5-4197-B856-69219C2A3845"
+    case battery = "180F"
 }
 
 enum MainServiceCharacteristicUUID: String, CBUUIDRawValue {
@@ -28,6 +29,10 @@ enum MainServiceCharacteristicUUID: String, CBUUIDRawValue {
     case timerTick       = "6E6C7910-B89E-43A5-78AF-50C5E2B86F7E"
     case firmwareVersion = "30D99DC9-7C91-4295-A051-0A104D238CF2"
     case ledMode         = "C6D84241-F1A7-4F9C-A25F-FCE16732F14E"
+}
+
+enum BatteryServiceCharacteristicUUID: String, CBUUIDRawValue {
+    case battery_level   = "2A19"
 }
 
 enum RileyLinkLEDMode: UInt8 {
@@ -48,6 +53,9 @@ extension PeripheralManager.Configuration {
                     MainServiceCharacteristicUUID.timerTick.cbUUID,
                     MainServiceCharacteristicUUID.firmwareVersion.cbUUID,
                     MainServiceCharacteristicUUID.ledMode.cbUUID
+                    ],
+                RileyLinkServiceUUID.battery.cbUUID: [
+                    BatteryServiceCharacteristicUUID.battery_level.cbUUID
                 ]
             ],
             notifyingCharacteristics: [
@@ -74,6 +82,17 @@ extension PeripheralManager.Configuration {
 
 fileprivate extension CBPeripheral {
     func getCharacteristicWithUUID(_ uuid: MainServiceCharacteristicUUID, serviceUUID: RileyLinkServiceUUID = .main) -> CBCharacteristic? {
+        guard let service = services?.itemWithUUID(serviceUUID.cbUUID) else {
+            return nil
+        }
+
+        return service.characteristics?.itemWithUUID(uuid.cbUUID)
+    }
+}
+
+
+fileprivate extension CBPeripheral {
+    func getBatteryCharacteristic(_ uuid: BatteryServiceCharacteristicUUID, serviceUUID: RileyLinkServiceUUID = .battery) -> CBCharacteristic? {
         guard let service = services?.itemWithUUID(serviceUUID.cbUUID) else {
             return nil
         }
@@ -286,6 +305,25 @@ extension PeripheralManager {
             }
 
             return version
+        } catch let error as PeripheralManagerError {
+            throw RileyLinkDeviceError.peripheralManagerError(error)
+        }
+    }
+
+    func readBatteryLevel(timeout: TimeInterval) throws -> String {
+        guard let characteristic = peripheral.getBatteryCharacteristic(.battery_level) else {
+            throw RileyLinkDeviceError.peripheralManagerError(.unknownCharacteristic)
+        }
+
+        do {
+            guard let data = try readValue(for: characteristic, timeout: timeout) else {
+                // TODO: This is an "unknown value" issue, not a timeout
+                throw RileyLinkDeviceError.peripheralManagerError(.timeout)
+            }
+
+            let battery_level = "\(data[0])"
+
+            return battery_level
         } catch let error as PeripheralManagerError {
             throw RileyLinkDeviceError.peripheralManagerError(error)
         }

--- a/RileyLinkBLEKit/RileyLinkDevice.swift
+++ b/RileyLinkBLEKit/RileyLinkDevice.swift
@@ -93,6 +93,12 @@ extension RileyLinkDevice {
         manager.setCustomName(name)
     }
     
+    public func getBatterylevel(_ completion: @escaping (_ batteryLevel: String?) -> Void) {
+        self.manager.queue.async {
+            completion(try? self.manager.readBatteryLevel(timeout: 1))
+        }
+    }
+    
     public func enableBLELEDs() {
         manager.setLEDMode(mode: .on)
     }

--- a/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -42,6 +42,16 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
         }
     }
     
+    private var battery: String? {
+        didSet {
+            guard isViewLoaded else {
+                return
+            }
+
+            cellForRow(.battery)?.setDetailBatteryLevel(battery, device.name)
+        }
+    }
+    
     private var frequency: Measurement<UnitFrequency>? {
         didSet {
             guard isViewLoaded else {
@@ -110,6 +120,14 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 }
             } catch let error {
                 self.log.error("Failed to get stats for uptime: %{public}@", String(describing: error))
+            }
+        }
+    }
+    
+    func updateBatteryLevel() {
+        device.getBatterylevel { (batteryLevel) in
+            DispatchQueue.main.async {
+                    self.battery = batteryLevel
             }
         }
     }
@@ -185,6 +203,7 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
 
         updateUptime()
         
+        updateBatteryLevel()
     }
     
     public override func viewWillDisappear(_ animated: Bool) {
@@ -237,6 +256,7 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
         case connection
         case uptime
         case frequency
+        case battery
     }
 
     private func cellForRow(_ row: DeviceRow) -> UITableViewCell? {
@@ -289,6 +309,9 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
             case .frequency:
                 cell.textLabel?.text = LocalizedString("Frequency", comment: "The title of the cell showing current rileylink frequency")
                 cell.setDetailFrequency(frequency, formatter: frequencyFormatter)
+            case .battery:
+                cell.textLabel?.text = NSLocalizedString("Battery Level", comment: "The title of the cell showing battery level")
+                cell.setDetailBatteryLevel(battery, device.name)
             }
         case .commands:
             cell.accessoryType = .disclosureIndicator
@@ -399,6 +422,15 @@ private extension UITableViewCell {
             detailTextLabel?.text = age.format(using: [.day, .hour, .minute])
         } else {
             detailTextLabel?.text = ""
+        }
+    }
+
+   func setDetailBatteryLevel(_ batteryLevel: String?, _ name: String?) {
+        if let batteryLevel = batteryLevel, let name = name {
+            // check for EmaLink within the device name
+            detailTextLabel?.text = name.lowercased().contains("emalink") ? batteryLevel + " %" : "N/A"
+        } else {
+            detailTextLabel?.text = "N/A"
         }
     }
     


### PR DESCRIPTION
The EmaLink (https://github.com/sks01/EmaLink/) reports battery level accurately. 
The code here adds battery information in the RileyLink device menu. 
A percentage will be displayed if the device name contains 'emalink' or the value reported is different than 77 (77 is the default value reported by the RileyLink). If none of these are true then 'N/A' is shown.

For an EmaLink:
<img src="https://user-images.githubusercontent.com/16063287/88604047-7e2bc880-d06e-11ea-8810-31e1e3975ca5.jpg" width="400">
<br>
For a RileyLink:
<img src="https://user-images.githubusercontent.com/16063287/88604071-8b48b780-d06e-11ea-889c-844d9664896c.jpg" width="400">
